### PR TITLE
Fix shared build for rocksdb

### DIFF
--- a/recipes/rocksdb/all/CMakeLists.txt
+++ b/recipes/rocksdb/all/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12)
 PROJECT(conancmakewrapper)
 
-message(STATUS "Conan CMake Wrapper")
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
 include("${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake")
 CONAN_BASIC_SETUP()
 
-include("CMakeListsOriginal.cmake")
+add_subdirectory("source_subfolder")

--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "6.4.6":
     sha256: 540BBF9369A31E0891FCB4056A36FFA439C59FC179AA0B1F46E3478417F97643
     url: https://github.com/facebook/rocksdb/archive/v6.4.6.tar.gz
+patches:
+  "6.4.6":
+    - base_path: source_subfolder
+      patch_file: patches/0001-build-libs.patch

--- a/recipes/rocksdb/all/patches/0001-build-libs.patch
+++ b/recipes/rocksdb/all/patches/0001-build-libs.patch
@@ -1,0 +1,60 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7266f3b..b8f6397 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -772,6 +772,7 @@ else()
+   set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT})
+   set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+ 
++  if (BUILD_SHARED_LIBS)
+   add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
+   target_link_libraries(${ROCKSDB_SHARED_LIB}
+     ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+@@ -781,18 +782,23 @@ else()
+                         SOVERSION ${ROCKSDB_VERSION_MAJOR}
+                         CXX_STANDARD 11
+                         OUTPUT_NAME "rocksdb")
++  endif()
+ endif()
+ 
++if (NOT BUILD_SHARED_LIBS)
+ add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES})
+ target_link_libraries(${ROCKSDB_STATIC_LIB}
+   ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
++endif()
+ 
+ if(WIN32)
++  if (BUILD_SHARED_LIBS)
+   add_library(${ROCKSDB_IMPORT_LIB} SHARED ${SOURCES})
+   target_link_libraries(${ROCKSDB_IMPORT_LIB}
+     ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+   set_target_properties(${ROCKSDB_IMPORT_LIB} PROPERTIES
+     COMPILE_DEFINITIONS "ROCKSDB_DLL;ROCKSDB_LIBRARY_EXPORTS")
++  endif()
+   if(MSVC)
+     set_target_properties(${ROCKSDB_STATIC_LIB} PROPERTIES
+       COMPILE_FLAGS "/Fd${CMAKE_CFG_INTDIR}/${ROCKSDB_STATIC_LIB}.pdb")
+@@ -839,6 +845,7 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
+ 
+   install(DIRECTORY include/rocksdb COMPONENT devel DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
++  if (NOT BUILD_SHARED_LIBS)
+   install(
+     TARGETS ${ROCKSDB_STATIC_LIB}
+     EXPORT RocksDBTargets
+@@ -846,6 +853,7 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
+     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+   )
++  else()
+ 
+   install(
+     TARGETS ${ROCKSDB_SHARED_LIB}
+@@ -856,6 +864,7 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
+     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+   )
++  endif()
+ 
+   install(
+     EXPORT RocksDBTargets

--- a/recipes/rocksdb/all/test_package/CMakeLists.txt
+++ b/recipes/rocksdb/all/test_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -9,3 +8,4 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/rocksdb/all/test_package/test_package.cpp
+++ b/recipes/rocksdb/all/test_package/test_package.cpp
@@ -1,12 +1,12 @@
-
-#include <cassert>
-
+#include <cstdlib>
 #include "rocksdb/db.h"
 
 int main() {
   rocksdb::DB* db;
   rocksdb::Options options;
   options.create_if_missing = true;
-  rocksdb::Status status = rocksdb::DB::Open(options, "./testdb", &db);
-  assert(status.ok());
+  rocksdb::Status status = rocksdb::DB::Open(options, "testdb", &db);
+  status.ok();
+
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Specify library name and version:  **rocksdb/6.4.6**

This PR is able to solve the problem of library installation. By default, Rocksdb installs both shared and static libraries.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

