### PR TITLE
Add rocksdb version 6.8.1 and fix shared library variant

### DIFF
--- a/recipes/rocksdb/all/conandata.yml
+++ b/recipes/rocksdb/all/conandata.yml
@@ -1,8 +1,5 @@
 sources:
-  "20200417":
-    sha256: b3d3ee146e8453e74124243bb7b06d7da8db9f00458aeb6dcbccb37346ab147d
-    url: https://github.com/facebook/rocksdb/archive/9e6f3efcd2fd956d01d56f598838f0917e238a2d.zip
-patches:
-  "20200417":
-    - patch_file: "patches/6724.patch"
-      base_path: "source_subfolder"
+  "6.8.1":
+    url: https://github.com/facebook/rocksdb/archive/v6.8.1.tar.gz
+    sha256: ca192a06ed3bcb9f09060add7e9d0daee1ae7a8705a3d5ecbe41867c5e2796a2
+

--- a/recipes/rocksdb/all/test_package/CMakeLists.txt
+++ b/recipes/rocksdb/all/test_package/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
+if(NOT ROCKSDB_DLL)
+    add_executable(test_package_cpp test_package.cpp)
+    target_link_libraries(test_package_cpp ${CONAN_LIBS})
+endif()
+
+add_executable(test_package_c test_package.c)
+target_link_libraries(test_package_c ${CONAN_LIBS})

--- a/recipes/rocksdb/all/test_package/conanfile.py
+++ b/recipes/rocksdb/all/test_package/conanfile.py
@@ -8,10 +8,16 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["ROCKSDB_DLL"] = self.options["rocksdb"].shared
+
         cmake.configure()
         cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
+            if not self.options["rocksdb"].shared:
+                bin_path = os.path.join("bin", "test_package_cpp")
+                self.run(bin_path, run_environment=True)
+
+            bin_path = os.path.join("bin", "test_package_c")
             self.run(bin_path, run_environment=True)

--- a/recipes/rocksdb/all/test_package/test_package.c
+++ b/recipes/rocksdb/all/test_package/test_package.c
@@ -1,0 +1,26 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "rocksdb/c.h"
+
+int main() {
+  rocksdb_options_t *options = rocksdb_options_create();
+  rocksdb_options_set_create_if_missing(options, 1);
+  char* err = NULL;
+  rocksdb_t* db = rocksdb_open(options, "testdb", &err);
+
+  if (!db) {
+    printf("DB error: %s\n", err);
+  } else {
+    rocksdb_free(db);
+  }
+
+  if(err) {
+    rocksdb_free(err);
+  }
+
+  if(options) {
+    rocksdb_free(options);
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/recipes/rocksdb/all/test_package/test_package.cpp
+++ b/recipes/rocksdb/all/test_package/test_package.cpp
@@ -9,7 +9,7 @@ int main() {
   rocksdb::Status status = rocksdb::DB::Open(options, "testdb", &db);
   
   if (!status.ok()) {
-    std::cerr << "DB error: " << status.ToString();
+    std::cerr << "DB error: " << status.ToString() << std::endl;
   }
 
   return EXIT_SUCCESS;

--- a/recipes/rocksdb/config.yml
+++ b/recipes/rocksdb/config.yml
@@ -1,4 +1,6 @@
 ---
 versions:
+  "6.8.1":
+    folder: all
   "20200417":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **rocksdb/6.8.1**

The shared variant is packaged only with C API : rocksdb/c.h, it is mandatory for Windows target plateform, and it as been forced for unix. I don't know if we want to give the hability to use C++ API for shared on unix or not.
Appart from that, I don't know where you had problem with 8.6.1, I dropped the master version. Maybe your issue has been fixed in 8.6.1

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

